### PR TITLE
Feature#40 alert style

### DIFF
--- a/app/assets/stylesheets/home/components/prices/prices.scss
+++ b/app/assets/stylesheets/home/components/prices/prices.scss
@@ -32,7 +32,7 @@
   box-shadow: 0px 2px 5px rgb(107, 106, 106);
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: $breakpoint-desktop) {
   .prices-box {
     width: 32%;
     float: left;
@@ -40,6 +40,9 @@
   }
   .prices-box:last-child {
     margin-right: 0;
+  }
+  .prices-table {
+    margin-left: 8.5%;
   }
 }
 

--- a/app/assets/stylesheets/home/home.scss
+++ b/app/assets/stylesheets/home/home.scss
@@ -1,8 +1,52 @@
 // Place all the styles related to the Home controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+@import 'components/variables';
+
 body{
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
+$alert-color: #f42e2f;
+$notice-color: #8cf7ff;
+
+%alerts-style {
+  position: relative;
+  height: 58px;
+  border-radius: 25px;
+  margin: auto;
+  text-align: center;
+  padding: auto;
+  padding-top: 17px;
+}
+
+.alert {
+  width: 300px;
+  color: white;
+  margin-bottom: 3%;
+  background-color: $alert-color;
+  @extend %alerts-style;
+}
+
+.notice {
+  width: 300px;
+  background-color: $notice-color;
+  margin-bottom: 3%;
+  @extend %alerts-style;
+  
+}
+
+@media (min-width: $breakpoint-desktop) {
+  .alert {
+    width: 500px;
+    @extend %alerts-style;
+    margin-bottom: 2%;
+  }
+  
+  .notice {
+    width: 500px;
+    @extend %alerts-style;
+    margin-bottom: 2%;
+  }
+}
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
   
   around_action :switch_locale
 
@@ -11,4 +12,11 @@ class ApplicationController < ActionController::Base
     { locale: I18n.locale }
   end
   
+  
+
+  protected
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :gender, :phone, :country, :birth, :description, :professional_register, :speciality, :price])
+    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:name, :email, :description, :password, :password_confirmation, :current_password) }
+  end
 end

--- a/app/views/home/type.html.erb
+++ b/app/views/home/type.html.erb
@@ -7,7 +7,7 @@
     <% if params['commit'] == 'sign_up' %>
       <div class="type-buttons-psychologist
                   shadow p-3 mb-5 bg-body rounded">
-        <h3><%= t('psycho_type') %></h3>
+        <h3><%= t('psychologist_type') %></h3>
         <%= link_to image_tag("undraw_doctors_hwty.svg", class:"type-buttons-psychologist_img mt-2"), new_psychologist_registration_path%>
       </div>
 
@@ -20,7 +20,7 @@
     <% elsif params['commit'] == 'sign_in' %>
       <div class="type-buttons-psychologist
                   shadow p-3 mb-5 bg-body rounded">
-        <h3><%= t('psycho_type') %></h3>
+        <h3><%= t('psychologist_type') %></h3>
         <%= link_to image_tag("undraw_doctors_hwty.svg", class:"type-buttons-psychologist_img mt-2"), new_psychologist_session_path%>
       </div>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,7 +17,7 @@
 
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-        <%= link_to t('psychologists'),  psychologists_list_path, class: "nav-item nav-link"%>
+        <%= link_to t('psychologist'),  psychologists_list_path, class: "nav-item nav-link"%>
         <%= link_to t('prices'), prices_path, class: "nav-item nav-link"%> 
         <%= link_to t('faqs'), faqs_path, class: "nav-item nav-link"%>
         <%= link_to "Chat", nil, class: "nav-item nav-link"%>
@@ -48,7 +48,7 @@
   </div>
 
   <div class="nav-links">
-    <%= link_to t('psychologists'), psychologists_list_path , class:"nav-links_item"%>
+    <%= link_to t('psychologist'), psychologists_list_path , class:"nav-links_item"%>
     <%= link_to t('prices'), prices_path, class:"nav-links_item"%>
     <%= link_to t('faqs') , faqs_path, class:"nav-links_item"%>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,17 +11,19 @@
   </head>
 
   <body>
-    <% if !notice && !alert %>
       <%= render 'layouts/navbar' %>
       <%= yield %>
-      <%= render 'layouts/footer' %>
-    <% else %>
-      <%= render 'layouts/navbar' %>
-      <%= yield %>
-      <%= render 'layouts/footer' %>
-      <p class="notice"> <%= notice %> </p>
-      <p class="alert"> <%= alert %> </p>
+      
+    <% flash.each do |type, msg| %>
+      <% if type == 'notice' %>
+        <div class="notice">
+      <% else %>
+        <div class="alert">
+      <%end%>
+        <%= msg %>
+        </div>
     <% end %>
+    <%= render 'layouts/footer' %>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/app/views/patients/registrations/new.html.erb
+++ b/app/views/patients/registrations/new.html.erb
@@ -28,7 +28,7 @@
     <div class="field">
       <% if @minimum_password_length %>
       <% end %>
-      <%= f.password_field :password, class: 'form_field', placeholder: t('password_lenght'), autocomplete: "new-password" %>
+      <%= f.password_field :password, class: 'form_field', placeholder: t('password_length'), autocomplete: "new-password" %>
     </div>
 
     <div class="field">
@@ -46,9 +46,9 @@
           <%= f.radio_button(:gender, "female") %>
           <%= f.label(:gender, t('female'), value: "female")%>
         </div>
-        <div class="binary">
+        <div class="non-binary">
           <%= f.radio_button(:gender, "Non-Binary") %>
-          <%= f.label(:gender, t('other'), value: "non-binary")%>
+          <%= f.label(:gender, t('non_binary'), value: "non-binary")%>
         </div>
       </div>
     </div>

--- a/app/views/psychologists/registrations/new.html.erb
+++ b/app/views/psychologists/registrations/new.html.erb
@@ -26,7 +26,7 @@
     </div>
 
     <div class="field">
-      <%= f.password_field :password, class: 'form_field', placeholder:t('password_lenght')  %>
+      <%= f.password_field :password, class: 'form_field', placeholder:t('password_length')  %>
     </div>
 
     <div class="field">
@@ -57,9 +57,9 @@
           <%= f.radio_button(:gender, "female") %>
           <%= f.label(:gender, t('female'), value: "female")%>
         </div>
-        <div class="binary">
+        <div class="non-binary">
           <%= f.radio_button(:gender, "Non-Binary") %>
-          <%= f.label(:gender, t('other'), value: "non-binary")%>
+          <%= f.label(:gender, t('non_binary'), value: "non-binary")%>
         </div>
       </div>
     </div>

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -1,7 +1,7 @@
 es:
   devise:
     confirmations:
-      confirmed: "Tu cuenta ya ha sido confirmada. Has sido indentificado."
+      confirmed: "Tu cuenta ya ha sido confirmada. Has sido identificado."
       send_instructions: "Recibirás un correo electrónico en unos minutos con instrucciones sobre cómo reestablecer tu contraseña."
       send_paranoid_instructions: "Si tu correo electrónico existe en nuestra base de datos, recibirás un correo electrónico en unos minutos con instrucciones sobre cómo reiniciar tu contraseña."
     failure:

--- a/config/locales/views/home/en.yml
+++ b/config/locales/views/home/en.yml
@@ -56,5 +56,5 @@ en:
 
   # TYPE
   type_question: "Hi, what are you?"
-  psycho_type: "Psychologist"
+  psychologist_type: "Psychologist"
   patient_type: "Patient"

--- a/config/locales/views/home/es.yml
+++ b/config/locales/views/home/es.yml
@@ -55,5 +55,5 @@ es:
 
   # TYPE
   type_question: "Hola, ¿qué eres?"
-  psycho_type: "Psicológo"
+  psychologist_type: "Psicológo"
   patient_type: "Paciente"

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -31,7 +31,7 @@
 
 en:
   hello: "Hello world"
-  psycho: "Psychologist"
+  psychologist: "Psychologist"
   prices: "Prices"
   faqs: "FAQS"
   sign_up: "Sign Up"

--- a/config/locales/views/layouts/es.yml
+++ b/config/locales/views/layouts/es.yml
@@ -1,5 +1,5 @@
 es:
-  psycho: "Psicólogo"
+  psychologist: "Psicólogo"
   prices: "Precios"
   faqs: "Preguntas Frecuentes"
   sign_up: "Registrate"

--- a/config/locales/views/patients/en.yml
+++ b/config/locales/views/patients/en.yml
@@ -2,12 +2,12 @@ en:
   greeting: "Hello!"
   new_account: "Create New Account Here."
   name: "Full Name"
-  password_lenght: "Password (6 characters minimum)"
+  password_length: "Password (6 characters minimum)"
   password_confirmation: "Password confirmation"
   gender: "Select your gender"
   male: "Male"
   female: "Female"
-  other: "Non-binary"
+  non_binary: "Non-binary"
   account_question: "Do you have an account?"
 
   # LINKS

--- a/config/locales/views/patients/es.yml
+++ b/config/locales/views/patients/es.yml
@@ -2,12 +2,12 @@ es:
   greeting: "Hola!"
   new_account: "Crea Una Nueva Cuenta Aquí."
   name: "Nombre Completo"
-  password_lenght: "Contraseña (6 carácteres minímo)"
+  password_length: "Contraseña (6 carácteres minímo)"
   password_confirmation: "Confirma tu contraseña"
   gender: "Selecciona tu género"
   male: "Hombre"
   female: "Mujer"
-  other: "No binario"
+  non_binary: "No binario"
   account_question: "¿Ya tienes una cuenta?"
 
   # LINKS


### PR DESCRIPTION
# Description
What did you implement/Why did you implement this:
 - What? Add styles for messages
 - Why? To distinguish easily between an alert and a notice message
 - Fix some typo mistakes
 - Align prices blocks
 - What? Fix trouble when a new psychologist create an account
 - Why? Because the professional data was not saved.

Resolve #40 

  ## Screenshots 
Notice message
 - Desktop
![imagen](https://user-images.githubusercontent.com/38772008/132294582-b54f333f-36db-4936-830b-a07036dc127d.png)
 - Mobile
![imagen](https://user-images.githubusercontent.com/38772008/132294758-4624bfa4-b1a9-4b1e-8384-1d56437c9d56.png)

Alert Message
 - Desktop
![imagen](https://user-images.githubusercontent.com/38772008/132294689-6b601e37-5ae6-4d4e-b40a-3ee5d4a860b6.png)
 - Mobile
![imagen](https://user-images.githubusercontent.com/38772008/132294732-fe70de1b-2f1e-49f9-9b4c-0153f3bb1d4d.png)

